### PR TITLE
Reproducing the bug in DebounceFirst

### DIFF
--- a/circuit-breaker/debounce.go
+++ b/circuit-breaker/debounce.go
@@ -17,16 +17,19 @@ func DebounceFirst(circuit Circuit, d time.Duration) Circuit {
 
 	return func(ctx context.Context) (string, error) {
 		m.Lock()
-		defer m.Unlock()
+
+		defer func() {
+			threshold = time.Now().Add(d)
+			m.Unlock()
+		}()
 
 		// If the threshold has not been reached, return the previous result
-		if !threshold.IsZero() && time.Now().Before(threshold) {
+		if time.Now().Before(threshold) {
 			return result, err
 		}
 
 		// Execute the circuit and set the threshold for future calls
 		result, err = circuit(ctx)
-		threshold = time.Now().Add(d)
 
 		return result, err
 	}


### PR DESCRIPTION
As per the implementation in the book, each thread acquires the lock & then enters the `defer` function. With this workflow every single thread will keep on extending the `threshold` by adding the duration to existing `threshold`. Therefore `time.Now().Before(threshold)` check will always be `true`.

This diff results in the original implementation of `DebounceFirst` as presented in the book.

The failing test is: https://github.com/varunu28/Go-Cloud-Patterns/blob/main/circuit-breaker/debounce_test.go
The implementation with which test ends up passing is: https://github.com/varunu28/Go-Cloud-Patterns/blob/main/circuit-breaker/debounce.go#L12-L33